### PR TITLE
Update PublishDir.groovy

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/processor/PublishDir.groovy
@@ -137,6 +137,10 @@ class PublishDir {
         this.mode = mode
     }
 
+    void setMode( Closure value )  {
+        setMode(value.call() as String)
+    }
+
     static @PackageScope Map<String,String> resolveTags( tags ) {
         def result = tags instanceof Closure
                 ? tags.call()


### PR DESCRIPTION
Add Closure as possible PublishDir.setMode() input
This is related to #4024

This have been tested and work.

Exemple:
```groovy
process {
  ext {
    Output_copy = false
  }
  publishDir {
    mode = { task.ext.Output_copy ? 'copy' : 'symlink' }
  }

  withName: 'FOO' {
    ext.Output_copy = true
  }

  withName: 'BAR' {
    ext.Output_copy = false
  }
}
``` 
Only results of the FOO process will be copied.

WARNING:
I expect the closure to return a String, so it won't work if it returns `null` for exemple. Maybe it should handle it?

